### PR TITLE
Better bicycle routing

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -425,15 +425,19 @@
 		</point>
 	</routingProfile>
 
-	<routingProfile name="bicycle" baseProfile="bicycle" restrictionsAware="true" minDefaultSpeed="7" maxDefaultSpeed="27"
-			leftTurn="0" rightTurn="0" followSpeedLimitations="false" onewayAware="true" heuristicCoefficient="1.5">
+	<routingProfile name="bicycle" baseProfile="bicycle" restrictionsAware="true" minDefaultSpeed="2" maxDefaultSpeed="25.5"
+			leftTurn="0" rightTurn="0" followSpeedLimitations="false" onewayAware="true" heuristicCoefficient="1.4">
 		<!-- <attribute name="relaxNodesIfStartDistSmallCoeff" value="2.5"/>  -->
 		<!-- New ROUTING API -->
-		<parameter id="avoid_ferries" name="Avoid ferries" description="Avoid ferries" type="boolean"/>
-		<parameter id="avoid_motorway" name="Avoid motorways" description="Avoid motorways" type="boolean"/>
+
+		<parameter id="avoid_traffic_signals" name="Less Traffic Signals - Less Main Roads" description="Avoid Traffic Signals" type="boolean"/>
 		<parameter id="avoid_unpaved" name="Avoid unpaved roads" description="Avoid unpaved roads" type="boolean"/>
+		<parameter id="avoid_ferries" name="Avoid ferries" description="Avoid ferries" type="boolean"/>
 		<parameter id="avoid_stairs" name="Avoid stairs" description="Avoid stairs" type="boolean"/>
 		<parameter id="avoid_borders" name="Avoid border crossing" description="Avoid crossing a border into another country" type="boolean"/>
+		<parameter id="avoid_motorway" name="Avoid motorways" description="Avoid motorways" type="boolean"/>
+
+
 
 		<way attribute="access">
 			<select value="-1" t="osmand_change" v="delete"/>
@@ -450,6 +454,9 @@
 				<if param="avoid_stairs"/>
 			</select>
 
+			<select value="-1" t="highway" v="elevator"/>
+			<select value="-1" t="highway" v="construction"/>
+			<select value="-1" t="motorroad" v="yes"/>
 			<select value="-1" t="bicycle" v="no"/>
 			<select value="1"  t="bicycle" v="yes"/>
 			<select value="1"  t="bicycle" v="permissive"/>
@@ -459,17 +466,17 @@
 			<select value="1"  t="bicycle" v="use_sidepath"/>
 			<select value="1"  t="bicycle" v="dismount"/>
 
-			<select value="-1" t="vehicle" v="no"/>
-			<select value="-1" t="vehicle" v="agricultural"/>
-			<select value="-1" t="vehicle" v="forestry"/>
+			<select value="1" t="vehicle" v="no"/>
+			<select value="1" t="vehicle" v="agricultural"/>
+			<select value="1" t="vehicle" v="forestry"/>
 			<select value="1"  t="vehicle" v="yes"/>
 			<select value="1"  t="vehicle" v="permissive"/>
 			<select value="1"  t="vehicle" v="designated"/>
 			<select value="1"  t="vehicle" v="destination"/>
 
 			<select value="-1" t="access" v="no"/>
-			<select value="-1" t="access" v="agricultural"/>
-			<select value="-1" t="access" v="forestry"/>
+			<select value="1" t="access" v="agricultural"/>
+			<select value="1" t="access" v="forestry"/>
 			<select value="1"  t="access" v="yes"/>
 			<select value="1"  t="access" v="permissive"/>
 
@@ -514,45 +521,62 @@
 			<select value="1" t="oneway" v="yes"/>
 			<select value="1" t="oneway" v="1"/>
 			<select value="-1" t="oneway" v="-1"/>
-			<select value="1" t="roundabout"/>
+			<select value="1" t="roundabout" v="yes"/>
 			<select value="1" t="junction" v="roundabout"/>
 		</way>
 
 		<way attribute="speed" type="speed">
 			<select value="1"  t="highway" v="steps"/>
-			<select value="5"  t="route"   v="ferry"/>
-			<select value="4"  t="bicycle" v="dismount"/>
-			<select value="12" t="highway" v="motorway"/>
-			<select value="12" t="highway" v="motorway_link"/>
-			<select value="12" t="highway" v="trunk"/>
-			<select value="12" t="highway" v="trunk_link"/>
-			<select value="11" t="highway" v="primary"/>
-			<select value="11" t="highway" v="primary_link"/>
-			<select value="13" t="highway" v="secondary"/>
-			<select value="13" t="highway" v="secondary_link"/>
-			<select value="14" t="highway" v="tertiary"/>
-			<select value="14" t="highway" v="tertiary_link"/>
-			<select value="16" t="highway" v="road"/>
-			<select value="18" t="highway" v="residential"/>
-			<select value="18" t="highway" v="cycleway"/>
-			<select value="13" t="highway" v="unclassified"/>
-			<select value="13" t="highway" v="service"/>
-			<select value="12" t="highway" v="track"/>
-			<select value="12" t="highway" v="path"/>
-			<select value="18" t="highway" v="living_street"/>
+			<select value="3"  t="route"   v="ferry"/>
+			<select value="5.5"  t="bicycle" v="dismount"/>
+			<select value="5" t="highway" v="motorway"/>
+			<select value="5" t="highway" v="motorway_link"/>
+			<select value="5" t="highway" v="trunk"/>
+			<select value="5" t="highway" v="trunk_link"/>
+
+		<if param="avoid_traffic_signals">
+			<select value="8.1" t="highway" v="primary"/>
+			<select value="8.1" t="highway" v="primary_link"/>
+			<select value="9.5" t="highway" v="secondary"/>
+			<select value="9.5" t="highway" v="secondary_link"/>
+			<select value="13.2" t="highway" v="tertiary"/>
+			<select value="13.2" t="highway" v="tertiary_link"/>
+			<select value="22" t="highway" v="residential"/>
+			<select value="20.7" t="highway" v="cycleway"/>
+			<select value="20.7" t="highway" v="track"/>
+			<select value="18.9" t="highway" v="path"/>
+			<select value="18.8" t="highway" v="footway"/>
+		</if>
+
+
+			<select value="8.5" t="highway" v="primary"/>
+			<select value="8.5" t="highway" v="primary_link"/>
+			<select value="11" t="highway" v="secondary"/>
+			<select value="11" t="highway" v="secondary_link"/>
+			<select value="14.5" t="highway" v="tertiary"/>
+			<select value="14.5" t="highway" v="tertiary_link"/>
+			<select value="18.9" t="highway" v="road"/>
+			<select value="23.5" t="highway" v="residential"/>
+			<select value="19.1" t="highway" v="cycleway"/>
+			<select value="18.9" t="highway" v="unclassified"/>
+			<select value="16.5" t="highway" v="service"/>
+			<select value="19.0" t="highway" v="track"/>
+			<select value="17" t="highway" v="path"/>
+			<select value="20.7" t="highway" v="living_street"/>
 			<select value="14" t="highway" v="pedestrian"/>
-			<select value="14" t="highway" v="footway"/>
-			<select value="8"  t="highway" v="byway"/>
-			<select value="13" t="highway" v="platform"/>
+			<select value="16.5" t="highway" v="footway"/>
+			<select value="10"  t="highway" v="byway"/>
+			<select value="11" t="highway" v="platform"/>
 			<select value="13" t="highway" v="services"/>
-			<select value="13" t="highway" v="bridleway"/>
-			<select value="16"/>
+			<select value="2" t="highway" v="bridleway"/>
+			<select value="14.5"/>
 		</way>
 
 		<way attribute="priority">
 			<select value="0.1" t="bicycle" v="private"/>
-			<select value="0.1" t="bicycle" v="destination"/>
+			<select value="0.2" t="bicycle" v="destination"/>
 			<select value="0.1" t="access" v="private"/>
+			<select value="0.4" t="indoor" v="yes"/>
 			<select value="0.1" t="barrier" v="debris"/>
 			<select value="0.1" t="bicycle" v="use_sidepath"/>
 
@@ -572,30 +596,55 @@
 				<select value="0.1" t="surface" v="mud"/>
 				<select value="0.1" t="surface" v="pebblestone"/>
 				<select value="0.1" t="surface" v="sand"/>
-				<select value="0.1" t="surface" v="wood"/>
+				<select value="0.5" t="surface" v="wood"/>
 			</if>
 
-			<select value="0.5" t="bicycle" v="dismount"/>
-			
-			<select value="0.8" t="surface" v="gravel"/>
-			<select value="0.8" t="surface" v="unpaved"/>
-			<select value="0.8" t="surface" v="grass"/>
-			<select value="0.8" t="tracktype" v="grade4"/>
-			<select value="0.8" t="tracktype" v="grade5"/>
-			
-			<select value="1.6" t="cycleway" v="lane"/>
-			<select value="1.6" t="cycleway" v="opposite_lane"/>
-			<select value="1.6" t="cycleway" v="share_busway"/>
-			<select value="1.6" t="cycleway" v="track"/>
-			<select value="1.6" t="cycleway" v="opposite_track"/>
-			<select value="1.6" t="cycleway" v="shared"/>
-			<select value="1.6" t="cycleway" v="shared_lane"/>
-
-			<select value="1.5" t="highway" v="cycleway"/>
-
-			<select value="1.5" t="bicycle" v="official"/>
-			<select value="1.4" t="bicycle" v="designated"/>
+			<select value="1" t="bicycle" v="dismount"/>
+			<select value="0.5" t="cycleway" v="sidepath"/>
+			<select value="0.45" t="footway" v="sidewalk"/>
+			<select value="1.3" t="tracktype" v="grade1"/>
+			<select value="1.25" t="tracktype" v="grade2"/>
+			<select value="1.1" t="tracktype" v="grade3"/>
+			<select value="0.7" t="tracktype" v="grade4"/>
+			<select value="0.5" t="tracktype" v="grade5"/>
+			<select value="0.7" t="surface" v="cobblestone"/>
+			<select value="1.3" t="cycleway" v="lane"/>
+			<select value="1.3" t="cycleway" v="opposite_lane"/>
+			<select value="1.05" t="cycleway" v="share_busway"/>
+			<select value="1.3" t="cycleway" v="track"/>
+			<select value="1.3" t="cycleway" v="opposite_track"/>
+			<select value="0.8" t="cycleway" v="shared"/>
+			<select value="0.8" t="cycleway" v="shared_lane"/>
+			<select value="1.2" t="bridge" v="yes"/>
+			<select value="1.0" t="highway" v="primary"/>
+			<select value="1.0" t="highway" v="secondary"/>
+			<select value="1.0" t="highway" v="tertiary"/>
+			<select value="1.0" t="highway" v="residential"/>
+			<select value="1.35" t="surface" v="asphalt"/>
+			<select value="1.35" t="surface" v="paved"/>
+			<select value="1.35" t="surface" v="concrete"/>
+			<select value="1.35" t="surface" v="paving_stones"/>
+			<select value="1.0" t="highway" v="cycleway"/>
+			<select value="1.29" t="bicycle" v="official"/>
+			<select value="1.29" t="bicycle" v="designated"/>
 			<select value="1.2" t="bicycle" v="yes"/>
+			<select value="0.9" t="surface" v="gravel"/>
+			<select value="0.8" t="surface" v="unpaved"/>
+			<select value="0.75" t="surface" v="dirt"/>
+			<select value="0.75" t="surface" v="sand"/>
+			<select value="0.75" t="surface" v="earth"/>
+			<select value="0.75" t="surface" v="grass"/>
+			<select value="0.75" t="surface" v="ground"/>
+			<select value="0.5" t="surface" v="mud"/>
+			<select value="1.0" t="highway" v="road"/>
+			<select value="1.0" t="highway" v="unclassified"/>
+			<select value="1.0" t="highway" v="service"/>
+			<select value="1.1" t="surface" v="compacted"/>
+			<select value="1.1" t="surface" v="fine_gravel"/>
+			<select value="0.8" t="surface" v="wood"/>
+			<select value="0.76" t="highway" v="footway"/>
+			<select value="0.75" t="highway" v="track"/>
+			<select value="0.6" t="highway" v="path"/>
 
 			<select value="0.5" t="highway" v="motorway"/>
 			<select value="0.5" t="highway" v="motorway_link"/>
@@ -620,7 +669,6 @@
 			<select value="7"  t="highway" v="give_way"/>
 			<select value="25" t="highway" v="ford"/>
 			<select value="25" t="ford"/>
-
 			<select value="25" t="railway" v="crossing"/>
 			<select value="25" t="railway" v="level_crossing"/>
 		</point>
@@ -629,37 +677,42 @@
 			<if param="avoid_borders">
 				<select value="-1" t="barrier" v="border_control"/>
 			</if>
+
+			<if param="avoid_traffic_signals">
+			<select value="45" t="crossing" v="traffic_signals"/>
+			<select value="45" t="crossing" v="island;traffic_signals"/>
+			<select value="48" t="highway" v="traffic_signals"/>
+			</if>
+
+			<select value="13" t="crossing" v="traffic_signals"/>
+			<select value="13" t="crossing" v="island;traffic_signals"/>
+			<select value="19" t="highway" v="traffic_signals"/>
+			<select value="55"  t="highway" v="steps"/>
+			<select value="15"  t="bicycle" v="dismount"/>
+			<select value="240" t="route" v="ferry"/>
+			<select value="30" t="highway" v="ford"/>
+			<select value="30" t="ford" v="yes"/>
 			<select value="-1" t="bicycle" v="no"/>
 			<select value="1"  t="bicycle" v="yes"/>
 			<select value="1"  t="bicycle" v="permissive"/>
 			<select value="1"  t="bicycle" v="designated"/>
 			<select value="1"  t="bicycle" v="official"/>
 
-			<select value="-1" t="vehicle" v="no"/>
-			<select value="-1" t="vehicle" v="agricultural"/>
-			<select value="-1" t="vehicle" v="forestry"/>
+			<select value="1" t="vehicle" v="no"/>
+			<select value="1" t="vehicle" v="agricultural"/>
+			<select value="1" t="vehicle" v="forestry"/>
 			<select value="1"  t="vehicle" v="yes"/>
 			<select value="1"  t="vehicle" v="permissive"/>
 			<select value="1"  t="vehicle" v="designated"/>
 
 			<select value="-1" t="access" v="no"/>
-			<select value="-1" t="access" v="agricultural"/>
-			<select value="-1" t="access" v="forestry"/>
+			<select value="1" t="access" v="agricultural"/>
+			<select value="1" t="access" v="forestry"/>
 			<select value="1"  t="access" v="yes"/>
 			<select value="1"  t="access" v="permissive"/>
 
 			<select value="-1" t="crossing" v="no"/>
 
-			<select value="10" t="barrier" v="cycle_barrier"/>
-			<select value="5" t="barrier"/>
-			<select value="10" t="highway" v="traffic_signals"/>
-			<select value="10" t="crossing" v="unmarked"/>
-			<select value="5"  t="crossing" v="uncontrolled"/>
-			<select value="30" t="crossing" v="traffic_signals"/>
-			<select value="10" t="highway" v="stop"/>
-			<select value="7" t="highway" v="give_way"/>
-			<select value="25" t="highway" v="ford" />
-			<select value="25" t="ford" />
 		</point>
 	</routingProfile>
 
@@ -739,13 +792,6 @@
 			<!-- Additional tags -->
 			<select value="0.05" t="foot" v="private"/>
 			<select value="0.05" t="foot" v="destination"/>
-
-			<!-- Q? access=destination should not be used foot or what is the proposed schemeß
-			http://www.openstreetmap.org/way/173188624#map=18/39.56805/2.64846
-			should be 
-			<select value="0.05" t="access" v="private"/>
-			<select value="0.05" t="access" v="destination"/>
-		-->
 
 			<select value="1.2" t="sidewalk" v="yes"/>
 			<select value="0.9" t="sidewalk" v="no"/>

--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -559,12 +559,12 @@
 			<select value="23.5" t="highway" v="residential"/>
 			<select value="19.1" t="highway" v="cycleway"/>
 			<select value="18.9" t="highway" v="unclassified"/>
-			<select value="16.5" t="highway" v="service"/>
+			<select value="15.5" t="highway" v="service"/>
 			<select value="19.0" t="highway" v="track"/>
 			<select value="17" t="highway" v="path"/>
 			<select value="20.7" t="highway" v="living_street"/>
 			<select value="14" t="highway" v="pedestrian"/>
-			<select value="16.5" t="highway" v="footway"/>
+			<select value="15.5" t="highway" v="footway"/>
 			<select value="10"  t="highway" v="byway"/>
 			<select value="11" t="highway" v="platform"/>
 			<select value="13" t="highway" v="services"/>

--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -558,7 +558,7 @@
 			<select value="18.9" t="highway" v="road"/>
 			<select value="23.5" t="highway" v="residential"/>
 			<select value="19.1" t="highway" v="cycleway"/>
-			<select value="18.9" t="highway" v="unclassified"/>
+			<select value="22" t="highway" v="unclassified"/>
 			<select value="15.5" t="highway" v="service"/>
 			<select value="19.0" t="highway" v="track"/>
 			<select value="17" t="highway" v="path"/>
@@ -596,7 +596,7 @@
 				<select value="0.1" t="surface" v="mud"/>
 				<select value="0.1" t="surface" v="pebblestone"/>
 				<select value="0.1" t="surface" v="sand"/>
-				<select value="0.5" t="surface" v="wood"/>
+				<select value="0.6" t="surface" v="wood"/>
 			</if>
 
 			<select value="1" t="bicycle" v="dismount"/>
@@ -636,13 +636,13 @@
 			<select value="0.75" t="surface" v="grass"/>
 			<select value="0.75" t="surface" v="ground"/>
 			<select value="0.5" t="surface" v="mud"/>
-			<select value="1.0" t="highway" v="road"/>
-			<select value="1.0" t="highway" v="unclassified"/>
-			<select value="1.0" t="highway" v="service"/>
 			<select value="1.1" t="surface" v="compacted"/>
 			<select value="1.1" t="surface" v="fine_gravel"/>
-			<select value="0.8" t="surface" v="wood"/>
+			<select value="1.0" t="surface" v="wood"/>
 			<select value="0.76" t="highway" v="footway"/>
+			<select value="1.0" t="highway" v="unclassified"/>
+			<select value="1.0" t="highway" v="road"/>
+			<select value="1.0" t="highway" v="service"/>
 			<select value="0.75" t="highway" v="track"/>
 			<select value="0.6" t="highway" v="path"/>
 

--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -528,7 +528,7 @@
 		<way attribute="speed" type="speed">
 			<select value="1"  t="highway" v="steps"/>
 			<select value="3"  t="route"   v="ferry"/>
-			<select value="5.5"  t="bicycle" v="dismount"/>
+			<select value="5"  t="bicycle" v="dismount"/>
 			<select value="5" t="highway" v="motorway"/>
 			<select value="5" t="highway" v="motorway_link"/>
 			<select value="5" t="highway" v="trunk"/>

--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -425,7 +425,7 @@
 		</point>
 	</routingProfile>
 
-	<routingProfile name="bicycle" baseProfile="bicycle" restrictionsAware="true" minDefaultSpeed="2" maxDefaultSpeed="25.5"
+	<routingProfile name="bicycle" baseProfile="bicycle" restrictionsAware="true" minDefaultSpeed="2" maxDefaultSpeed="28.5"
 			leftTurn="0" rightTurn="0" followSpeedLimitations="false" onewayAware="true" heuristicCoefficient="1.4">
 		<!-- <attribute name="relaxNodesIfStartDistSmallCoeff" value="2.5"/>  -->
 		<!-- New ROUTING API -->
@@ -535,16 +535,16 @@
 			<select value="5" t="highway" v="trunk_link"/>
 
 		<if param="avoid_traffic_signals">
-			<select value="8.1" t="highway" v="primary"/>
-			<select value="8.1" t="highway" v="primary_link"/>
-			<select value="9.5" t="highway" v="secondary"/>
-			<select value="9.5" t="highway" v="secondary_link"/>
-			<select value="13.2" t="highway" v="tertiary"/>
-			<select value="13.2" t="highway" v="tertiary_link"/>
+			<select value="7" t="highway" v="primary"/>
+			<select value="7" t="highway" v="primary_link"/>
+			<select value="9" t="highway" v="secondary"/>
+			<select value="9" t="highway" v="secondary_link"/>
+			<select value="13" t="highway" v="tertiary"/>
+			<select value="13" t="highway" v="tertiary_link"/>
 			<select value="22" t="highway" v="residential"/>
-			<select value="20.7" t="highway" v="cycleway"/>
-			<select value="20.7" t="highway" v="track"/>
-			<select value="18.9" t="highway" v="path"/>
+			<select value="21" t="highway" v="cycleway"/>
+			<select value="22" t="highway" v="track"/>
+			<select value="19" t="highway" v="path"/>
 			<select value="18.8" t="highway" v="footway"/>
 		</if>
 
@@ -557,12 +557,12 @@
 			<select value="14.5" t="highway" v="tertiary_link"/>
 			<select value="18.9" t="highway" v="road"/>
 			<select value="23.5" t="highway" v="residential"/>
-			<select value="19.1" t="highway" v="cycleway"/>
-			<select value="22" t="highway" v="unclassified"/>
+			<select value="22.0" t="highway" v="cycleway"/>
+			<select value="23" t="highway" v="unclassified"/>
 			<select value="15.5" t="highway" v="service"/>
 			<select value="19.0" t="highway" v="track"/>
 			<select value="17" t="highway" v="path"/>
-			<select value="20.7" t="highway" v="living_street"/>
+			<select value="23" t="highway" v="living_street"/>
 			<select value="14" t="highway" v="pedestrian"/>
 			<select value="15.5" t="highway" v="footway"/>
 			<select value="10"  t="highway" v="byway"/>
@@ -603,19 +603,19 @@
 			<select value="0.5" t="cycleway" v="sidepath"/>
 			<select value="0.45" t="footway" v="sidewalk"/>
 			<select value="1.3" t="tracktype" v="grade1"/>
-			<select value="1.25" t="tracktype" v="grade2"/>
-			<select value="1.1" t="tracktype" v="grade3"/>
+			<select value="1.15" t="tracktype" v="grade2"/>
+			<select value="1.0" t="tracktype" v="grade3"/>
 			<select value="0.7" t="tracktype" v="grade4"/>
 			<select value="0.5" t="tracktype" v="grade5"/>
 			<select value="0.7" t="surface" v="cobblestone"/>
-			<select value="1.3" t="cycleway" v="lane"/>
-			<select value="1.3" t="cycleway" v="opposite_lane"/>
-			<select value="1.05" t="cycleway" v="share_busway"/>
-			<select value="1.3" t="cycleway" v="track"/>
-			<select value="1.3" t="cycleway" v="opposite_track"/>
+			<select value="1.5" t="cycleway" v="lane"/>
+			<select value="1.5" t="cycleway" v="opposite_lane"/>
+			<select value="1.1" t="cycleway" v="share_busway"/>
+			<select value="1.5" t="cycleway" v="track"/>
+			<select value="1.5" t="cycleway" v="opposite_track"/>
 			<select value="0.8" t="cycleway" v="shared"/>
 			<select value="0.8" t="cycleway" v="shared_lane"/>
-			<select value="1.2" t="bridge" v="yes"/>
+			<select value="1.1" t="bridge" v="yes"/>
 			<select value="1.0" t="highway" v="primary"/>
 			<select value="1.0" t="highway" v="secondary"/>
 			<select value="1.0" t="highway" v="tertiary"/>

--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -549,12 +549,12 @@
 		</if>
 
 
-			<select value="8.5" t="highway" v="primary"/>
-			<select value="8.5" t="highway" v="primary_link"/>
-			<select value="11" t="highway" v="secondary"/>
-			<select value="11" t="highway" v="secondary_link"/>
-			<select value="14.5" t="highway" v="tertiary"/>
-			<select value="14.5" t="highway" v="tertiary_link"/>
+			<select value="8" t="highway" v="primary"/>
+			<select value="8" t="highway" v="primary_link"/>
+			<select value="10.5" t="highway" v="secondary"/>
+			<select value="10.5" t="highway" v="secondary_link"/>
+			<select value="13.5" t="highway" v="tertiary"/>
+			<select value="13.5" t="highway" v="tertiary_link"/>
 			<select value="18.9" t="highway" v="road"/>
 			<select value="23.5" t="highway" v="residential"/>
 			<select value="22.0" t="highway" v="cycleway"/>
@@ -563,7 +563,7 @@
 			<select value="19.0" t="highway" v="track"/>
 			<select value="17" t="highway" v="path"/>
 			<select value="23" t="highway" v="living_street"/>
-			<select value="14" t="highway" v="pedestrian"/>
+			<select value="11" t="highway" v="pedestrian"/>
 			<select value="15.5" t="highway" v="footway"/>
 			<select value="10"  t="highway" v="byway"/>
 			<select value="11" t="highway" v="platform"/>


### PR DESCRIPTION
Dear all,

this is a suggestion for an improved bicycle routing. It is based on many, many days of work, tests and gradual improvements. It has been field tested extensively in Berlin (and tested virtually in France, Poland and Germany, with short and long distances).

After all those gradual improvements, I think it now works like magic: In almost any test I did, it found a better cycle route than the original version. A route with less car traffic (= less noise, less danger, less pollution). In most cases it will find great routes trough calm residential areas, parks, forests or along waterways. Still, it will find a fast route: It heavily prefers paved paths, tracks and roads. 

Some observations:
a) I recommend to check the box "Less Traffic Signals - Less Main Roads". Then it will find even more hidden byways without cars.
b) With that box checked, the route will normally be 10 to 15 percent longer (in kilometers), but often it will still be faster (because it avoids traffic lights).
c) If that box is unchecked, the route will be a compromise between the old version and the new version. 
d) At first glance, the coefficients might seem extreme, but tests show that they are balanced: Even the new version will use main roads (if they provide a real shortcut).
e) Please note that the new coefficients do not reflect real travel time _at all_. Instead, they only indicate preferences.

Please feel free to comment. I would also be glad if some people could test it! Apart from "real world tests" you can also do quick "virtual tests" with bike routes that you know well. 

Greetings from Berlin

Malte
